### PR TITLE
make text smaller with font overrides in main.scss

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,21 @@
+---
+# upgrade-friendly font size adjustment for Minimal Mistakes
+# see https://github.com/mmistakes/minimal-mistakes/issues/1219
+---
+@import "minimal-mistakes";
+
+html {
+  font-size: 14px; // change to whatever
+
+  @include breakpoint($medium) {
+    font-size: 14px; // change to whatever
+  }
+
+  @include breakpoint($large) {
+    font-size: 16px; // change to whatever
+  }
+
+  @include breakpoint($x-large) {
+    font-size: 18px; // change to whatever
+  }
+}


### PR DESCRIPTION
This adds one `.scss` file to override fonts in the new gem-installed minimal-mistakes theme.

We had smaller fonts before but they were done hackily by editing the `sass` files directly.  This adds an asset that controls how the real `main.css` is generated, and it keeps us out of the inner workings of Minimal Mistakes (making the site more upgrade-friendly).

See https://github.com/mmistakes/minimal-mistakes/issues/1219 for details on how this is done. Note that to get the solution there to work, we *had* to add the two `---` lines at the top of the file.

- [x] add main.scss
- [x] set font defaults to smaller values