### PR TITLE
Update blog and events with recent news

### DIFF
--- a/_posts/2021-04-22-ecp-videos.md
+++ b/_posts/2021-04-22-ecp-videos.md
@@ -1,0 +1,11 @@
+---
+layout: single
+title: "ECP annual meeting videos now available"
+date: 2021-04-22 00:02:00
+tags: exascale video ecp tutorial hpc
+---
+
+Spack is the software deployment tool of the Exascale Computing Project ([ECP](https://www.exascaleproject.org/)), a joint effort between the DOE Office of Science and NNSA that brings several together national labs. These combined forces tackle the hardware, software, and application challenges inherent in the DOE/NNSA's scientific and national security missions. The ECP's [annual meeting](https://www.ecpannualmeeting.com/) was hed virtually this year on April 12-16. The agenda included two Spack sessions that are now available on YouTube:
+
+- **Spack BoF** ([runtime 1:00:40](https://www.youtube.com/watch?v=BDriIk5oTbY&list=PLF590mYJUDzLEalO05fJHX99cbbUOd-1e&index=4)): This "birds of a feather" gathering details major developments in Spack releases, collaborative work with the [E4S](https://e4s-project.github.io/) team, roadmap for future development, and results from our [community survey](/spack-user-survey-2020/). The session was led by Todd Gamblin, Greg Becker, Tammy Dahlgren, Peter Scheibel, Richarda Butler, and Sergei Shudler.
+- **Using Spack to Accelerate Developer Workflows** ([runtime 6:14:42](https://www.youtube.com/watch?v=RlczUgwFCJg&list=PLF590mYJUDzLEalO05fJHX99cbbUOd-1e&index=9)): This tutorial focuses on developer workflows, covering covered installation, package authorship, Spack's dependency model, and Spack environments and configuration. Participants can learn new skills in this tutorial, even if they have participated in Spack tutorials in the past. Presenters were Todd Gamblin, Greg Becker, Peter Scheibel, Tammy Dahlgren, and Rob Blake. See also Spack's [tutorial docs](https://spack-tutorial.readthedocs.io/en/latest/).

--- a/events.md
+++ b/events.md
@@ -4,11 +4,22 @@ author_profile: false
 title: Events
 ---
 
+## 2021
+
+### [ISC High Performance](https://www.isc-hpc.com/)
+<small class="pull-right">24 June - 2 July 2021 | Online</small>  
+This year’s ISC conference will be held virtually. [Register](https://www.isc-hpc.com/registration-2021.html) to join us for the Spack community BoF and tutorial.
+
+
+### [ECP Annual Meeting](/ecp-annual-meeting-videos-now-available/)
+<small class="pull-right">12-16 April 2021 | Online</small>  
+The Exascale Computing Project's annual meeting was virtual this year. Spack hosted a BoF session and tutorial, both of which are posted to YouTube.
+
 ## 2020
 
 ### [Supercomputing (SC20)](/spack-at-sc20/)
 <small class="pull-right">9-19 November 2020 | Online</small>  
-This year SC20 is fully virtual with events and sessions conducted over two weeks. Check out the Spack lineup in this list.
+This year SC20 was fully virtual with events and sessions conducted over two weeks. Check out the Spack lineup in this list.
 
 
 ### [CppCon: Build All the Things with Spack](https://youtu.be/yuhV7iKRIJU)


### PR DESCRIPTION
Created a post about ECP videos
Added ECP annual meeting and upcoming ISC info to events page
ISC doesn't seem to have published the program schedule, so no specific days/times yet

FYI I could not preview these changes locally due to a combination of (I think) bundler and gem problems, neither of which I have been able to resolve this afternoon. Fingers crossed it's not a hot mess.