### PR TITLE
Add Spack CI status page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,3 +4,5 @@ main:
     url: /about/
   - title: "Blog"
     url: /blog/
+  - title: "Spack CI Status"
+    url: /status/

--- a/_data/status.yml
+++ b/_data/status.yml
@@ -1,0 +1,2 @@
+- date: Jan 25, 2023
+  message: <a href="https://gitlab.spack.io">https://gitlab.spack.io</a> will be down for maintenance on January 25th, 2023 from approximately 8AM - 3PM (PST).

--- a/_includes/status.html
+++ b/_includes/status.html
@@ -1,0 +1,12 @@
+<div>
+    <h2>
+        <span style="color: green;">&#10004;</span> All services are operational.
+    </h2>
+    <br />
+    <h1>Updates</h1>
+    {% for status in site.data.status %}
+        <h4>{{ status.date }}</h4>
+        <span>{{ status.message }}</span>
+        <hr />
+    {% endfor %}
+</div>

--- a/status.md
+++ b/status.md
@@ -1,0 +1,7 @@
+---
+layout: single
+author_profile: false
+title: Spack CI Status
+---
+
+{% include status.html %}


### PR DESCRIPTION
Adds a simple status page for Spack CI/gitlab.spack.io. 