### PR TITLE
Fix GH Pages deploy workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem "jekyll-sass-converter", "~> 2.0"
 end
 
 gem "webrick", "~> 1.7"


### PR DESCRIPTION
Fix found at https://community.cloudflare.com/t/deployment-failing-rubygems-version/446483/5.

It looks like `jekyll-sass-converter` 3.0 is breaking things.