### PR TITLE
Update old Slack links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -143,7 +143,7 @@ footer:
       url: https://github.com/spack/spack
     - label: "Slack"
       icon: "fab fa-slack"
-      url: "https://spackpm.herokuapp.com/"
+      url: "https://slack.spack.io"
     - label: "Docs"
       icon: "fas fa-book"
       url: https://spack.readthedocs.io/

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ header:
   - label: "<i class=\"fab fa-fw fa-twitter\"></i> Twitter"
     url: "https://twitter.com/spackpm"
   - label: "<i class=\"fab fa-slack\"></i> Slack"
-    url: "https://spackpm.herokuapp.com/"
+    url: "https://slack.spack.io"
   - label: "<i class=\"fas fa-book\"></i> Docs"
     url: "https://spack.readthedocs.io/"
   - label: "<i class=\"fab fa-google\"></i> Discussion"


### PR DESCRIPTION
This replaces the old Slack links that are no longer working with the working one (also mentioned by https://github.com/spack/spack.io/issues/47).