### PR TITLE
Remove downtime notice

### DIFF
--- a/_data/status.yml
+++ b/_data/status.yml
@@ -18,3 +18,6 @@
 
 - date: June 19, 2023
   message: <a href="https://gitlab.spack.io">https://gitlab.spack.io</a> is down for maintenance.
+
+- date: June 19, 2023
+  message: <a href="https://gitlab.spack.io">https://gitlab.spack.io</a> is back up.

--- a/_includes/status.html
+++ b/_includes/status.html
@@ -1,7 +1,7 @@
 <div>
     <h2>
-        {% comment %} <span style="color: green;">&#10004;</span> All services are operational.{% endcomment %}
-        &#9888;&#65039; Maintenance in progress. &#9888;&#65039;
+        <span style="color: green;">&#10004;</span> All services are operational.
+        {% comment %} &#9888;&#65039; Maintenance in progress. &#9888;&#65039;{% endcomment %}
     </h2>
     <br />
     <h1>Updates</h1>


### PR DESCRIPTION
Maintenance is complete and gitlab.spack.io is back up.