### PR TITLE
Add CNAME to main branch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+spack.io


### PR DESCRIPTION
It looks like the CNAME for the site was only on the `gh-pages` branch and thus running the action on the main branch wiped it out. This PR adds the CNAME back on the main branch to prevent this from happening again.