### PR TITLE
Fix typo in font awesome icon for matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ header:
     url: "https://twitter.com/spackpm"
   - label: "<i class=\"fab fa-slack\"></i> Slack"
     url: "https://slack.spack.io"
-  - label: "<i class=\"fab fa-comments\"></i> Matrix"
+  - label: "<i class=\"fa fa-comments\"></i> Matrix"
     url: "https://matrix.to/#/#spack-space:matrix.org"
   - label: "<i class=\"fas fa-book\"></i> Docs"
     url: "https://spack.readthedocs.io/"


### PR DESCRIPTION
As the title says, accidentally typo'd the font awesome icon for matrix in the index.html.