### PR TITLE
Update events through 2024

### DIFF
--- a/events.md
+++ b/events.md
@@ -4,67 +4,117 @@ author_profile: false
 title: Events
 ---
 
+## 2024
+
+### [HPCIC HPC Tutorials](https://hpcic.llnl.gov/tutorials/2024-hpc-tutorials)
+<small class="pull-right">6 - 7 August 2024 | Virtual</small>
+This is a free, full-day tutorial spread over two days. [Register (by 4 August)](https://llnlfed.webex.com/webappng/sites/llnlfed/webinar/webinarSeries/register/f0f129eba81946dc8a30552fc657ee94).
+
+### [PEARC 2024] (https://pearc.acm.org)
+<small class="pull-right">21 - 25 July 2024 | In person</small>
+[Register](https://web.cvent.com/event/f318e73c-2230-432a-a044-b75625020543/summary)
+
+### [Software Management Course at CSCS](https://www.cscs.ch)
+<small class="pull-right">13 June 2024 </small>
+Advanced Spack course [Slides] (https://spack.github.io/spack-cscs2024/)
+
+### [ISC High Performance](https://www.isc-hpc.com/)
+<small class="pull-right">12 - 16 May 2024 | In person</small>
+[Tutorial Slides] (https://spack-tutorial.readthedocs.io/en/isc24/)
+
+## 2023
+
+### [RADIUSS Tutorial Series 2023](https://aws.amazon.com/blogs/hpc/call-for-participation-radiuss-tutorial-series-2023/)
+<small class="pull-right">8 - 9 August 2023 | Virtual</small>
+Full-day tutorial spread over two days. [Tutorial Slides and Video](https://spack-tutorial.readthedocs.io/en/radiuss23/)
+
+### [PEARC 2023] (https://pearc.acm.org)
+<small class="pull-right">23 - 27 July 2023 | In person</small>
+[Tutorial Slides](https://spack-tutorial.readthedocs.io/en/pearc23/).
+
+### [CINECA 2023](https://www.max-centre.eu/events/cineca-admires-event-spack)
+<small class="pull-right">13 - 14 Feb 2023 | In person</small>
+[Tutorial Slides](https://spack-tutorial.readthedocs.io/en/cineca23/)
+
+## 2022
+
+### [RADIUSS AWS Tutorials 2022](https://software.llnl.gov/radiuss/event/2022/07/07/radiuss-on-aws/)
+<small class="pull-right">1 - 2 August 2022 | Virtual</small>
+This was a full-day tutorial spread over two days. [Slides](https://spack-tutorial.readthedocs.io/en/radiuss22/)
+
+### [PEARC 2022] (https://pearc.acm.org)
+<small class="pull-right">10 - 14 July 2022 | In person</small>
+[Tutorial Slides](https://spack-tutorial.readthedocs.io/en/pearc22/)
+
+### [ISC High Performance](https://www.isc-hpc.com/)
+<small class="pull-right">29 May 2022 | In person</small>
+[Tutorial Slides](https://spack-tutorial.readthedocs.io/en/isc22/)
+
 ## 2021
 
+### [Supercomputing (SC21)](
+<small class="pull-right">14 - 19 November 2021 | Hybrid</small>
+[Tutorial Slides](https://spack-tutorial.readthedocs.io/en/sc21/)
+
 ### [AHUG Hackathon: Cloud Hackathon for Arm-Based HPC](https://a-hug.org/hackathons/aws-hackathon/)
-<small class="pull-right">12 July 2021 (all week) | Online</small>  
+<small class="pull-right">12 July 2021 (all week) | Online</small>
 Spack joins AWS and the Arm HPC user group for a community hackathon beginning on July 12. Participating teams will choose from a list of codes that already have Spack recipes and use pre-built AWS clusters. The Spack team will be live on Zoom to whiteboard ideas and help with troubleshooting. [Register](https://docs.google.com/forms/d/e/1FAIpQLScQ5Kq3pNgtZVJrKdLQHTOp2xKu0ILyzlgmoGB6pdFZ62uyfg/viewform) or [read more](https://aws.amazon.com/blogs/hpc/aws-arm-hpc-hackathon-2021/) about what to expect.
 
 ### [ISC High Performance](https://www.isc-hpc.com/)
-<small class="pull-right">24 June - 2 July 2021 | Online</small>  
+<small class="pull-right">24 June - 2 July 2021 | Online</small>
 This year’s ISC conference will be held virtually. [Register](https://www.isc-hpc.com/registration-2021.html) to join us for the Spack community BoF and tutorial.
 
-* Thursday, 24 June, 5:00am – 9:00am PDT: [Tutorial: Managing HPC Software Complexity with Spack](https://app.swapcard.com/widget/event/isc-high-performance-2021-digital/planning/UGxhbm5pbmdfNDUzNTE3) 
+* Thursday, 24 June, 5:00am – 9:00am PDT: [Tutorial: Managing HPC Software Complexity with Spack](https://app.swapcard.com/widget/event/isc-high-performance-2021-digital/planning/UGxhbm5pbmdfNDUzNTE3)
 * Monday, 28 June, 8:35am – 9:10am PDT: [Spack Community Birds of a Feather](https://app.swapcard.com/widget/event/isc-high-performance-2021-digital/planning/UGxhbm5pbmdfNDQ0Njgz)
 
 ### [ECP Annual Meeting](/ecp-annual-meeting-videos-now-available/)
-<small class="pull-right">12-16 April 2021 | Online</small>  
+<small class="pull-right">12-16 April 2021 | Online</small>
 The Exascale Computing Project's annual meeting was virtual this year. Spack hosted a BoF session and tutorial, both of which are posted to YouTube.
 
 ## 2020
 
 ### [Supercomputing (SC20)](/spack-at-sc20/)
-<small class="pull-right">9-19 November 2020 | Online</small>  
+<small class="pull-right">9-19 November 2020 | Online</small>
 This year SC20 was fully virtual with events and sessions conducted over two weeks. Check out the Spack lineup in this list.
 
 
 ### [CppCon: Build All the Things with Spack](https://youtu.be/yuhV7iKRIJU)
-<small class="pull-right">20 October 2020 | Online</small>  
+<small class="pull-right">20 October 2020 | Online</small>
 CppCon is an annual, week-long gathering for the C++ community. This lightning talk describes Spack's build model and features and explains how to use it for any C++ project. The video runs 6:53.
 
 
 ### [Spack on FLOSS for Science Podcast](https://flossforscience.com/podcast/season3-epsiode-7)
-<small class="pull-right">3 September 2020 | Online</small>  
+<small class="pull-right">3 September 2020 | Online</small>
 The FLOSS for Science podcast showcases open source software uses in science. Episode 30 covers the philosophy of Spack, its package management capabilities in HPC clusters, supported operating systems, and much more. The episode runs 52:26.
 
 
 ### [Spack Tutorial on AWS](https://spacktutorialonaws.splashthat.com/)
-<small class="pull-right">28-29 July 2020 | Online</small>  
+<small class="pull-right">28-29 July 2020 | Online</small>
 Amazon Web Services is hosting a two-day Spack tutorial broadly targeted at HPC users, developers, and user support teams. Each day consists of two 1.5-hour sessions with a 30-minute break in the middle (4-7:30pm CET / 7-10:30pm PT). The first day will cover Spack basics, while the second day will dive deeper on advanced features. Videos from [day 1 (3:19:18)](https://www.youtube.com/watch?v=Os4k8SpZE3s) and [day 2 (3:30:18)](https://www.youtube.com/watch?v=lHTJBWisabo) are available.
 
 
 ### [HPC Best Practices Webinar Series](https://www.exascaleproject.org/event/what-is-new-in-spack/)
-<small class="pull-right">15 July 2020 | Online</small>  
+<small class="pull-right">15 July 2020 | Online</small>
 The IDEAS Productivity project, in partnership with the DOE Computing Facilities of the ALCF, OLCF, and NERSC and the DOE Exascale Computing Project, hosts a webinar series on Best Practices for HPC Software Developers. A webinar titled "What’s New in Spack?" will be presented by Todd Gamblin on Wednesday, July 15 at 1:00-2:00 pm ET. [Slides](https://www.exascaleproject.org/wp-content/uploads/2020/03/ideas-whats-new-in-spack.pdf) and a [video](https://www.youtube.com/watch?v=yDRx51PyHYw) (1:26:33) from the session are available.
 
 
 ### [ISC High Performance](https://www.isc-hpc.com/)
-<small class="pull-right">22-24 June 2020 | Frankfurt, Germany (DEFERRED)</small>  
+<small class="pull-right">22-24 June 2020 | Frankfurt, Germany (DEFERRED)</small>
 ISC (formerly known as the International Supercomputing Conference), the biggest Supercomputing event in Europe, is typically held in Frankfurt in June. This year’s conference has been replaced with a virtual event from June 22-24, but the virtual program will unfortunately not include BoFs (birds of a feather) or tutorials. The [Spack community BoF](https://www.isc-hpc.com/bof-sessions-2020.html) and [half-day tutorial](https://www.isc-hpc.com/tutorials-2020.html) will instead be held as part of the 2021 program.
 
 
 ### [RSE Stories Podcast: Spack Attack!](https://us-rse.org/rse-stories/2020/todd-gamblin/)
-<small class="pull-right">21 May 2020 | Online</small>  
+<small class="pull-right">21 May 2020 | Online</small>
 In a recent RSE Stories podcast, Todd Gamblin shares his journey at a national Lab and how getting angry at software led to development of a hugely popular package manager, Spack. The episode runs 21:25. RSE is affiliated with the U.S. Research Software Engineer Association.
 
 
 ### [Working Remotely: The Spack Team](https://bssw.io/blog_posts/working-remotely-the-spack-team)
-<small class="pull-right">16 May 2020 | Online</small>  
+<small class="pull-right">16 May 2020 | Online</small>
 Better Scientific Software’s blog features a post about the Spack team’s experience working remotely and interacting with the Spack community. The writeup offers insight into making the most of online communication opportunities and stresses the importance of providing robust documentation so users can help themselves.
 
 
 ### [CERN Grid Deployment Board Meeting](https://indico.cern.ch/event/813800/)
-<small class="pull-right">5 May 2020 | Geneva, Switzerland (REMOTE)</small>  
+<small class="pull-right">5 May 2020 | Geneva, Switzerland (REMOTE)</small>
 CERN operates the world's largest particle physics laboratory and is home to the Large Hadron Collider. As part of the Worldwide LHC Computing Grid Collaboration (WLCG), CERN's Grid Deployment Board will meet to talk about container distribution and modern packaging approaches -- like Spack. Notable presentations for the Spack community include:
 
 * Nikola Hardi, CERN: [ALICE Software Deployment](https://indico.cern.ch/event/813800/contributions/3843633/attachments/2032041/3401141/alice_nhardi_hsf_wlcg_pregdb_2020.pdf)
@@ -72,11 +122,11 @@ CERN operates the world's largest particle physics laboratory and is home to the
 * Ben Morgan, University of Warwick: [Spack - Implications on Software Deployment](https://indico.cern.ch/event/813800/contributions/3830178/attachments/2031805/3400697/SpackGDBMeeting_1.pdf)
 
 ### [ASC S3C](https://s3c.sandia.gov/)
-<small class="pull-right">14-16 April 2020 | Albuquerque, NM (POSTPONED)</small>  
+<small class="pull-right">14-16 April 2020 | Albuquerque, NM (POSTPONED)</small>
 The Tri-lab Advanced Simulation & Computing Sustainable Scientific Software Conference connects people from the ASC Tri-labs who are working to deliver scientific software solutions in a sustainable manner. Greg Becker will present a 20-minute talk and lead a half-day tutorial on Spack.
 
 ## 2019
 
 ### [Supercomputing (SC19)](/spack-at-sc19/)
-<small class="pull-right">17-22 November 2019 | Denver, CO</small>  
+<small class="pull-right">17-22 November 2019 | Denver, CO</small>
 SC19 kicks off this week in Denver, and there are Spack events *every day*. Make sure they're all on your calendar with this list.


### PR DESCRIPTION
This PR adds a number of events since the last update, including SC'21 and tutorials for which we have links to slides.  I debated whether to use "In person" or the actual location for a number of conferences.  Thoughts?

Note: The ISC'23 tutorial link in readthedocs points to the wrong event so I did not add it.  There's a similar problem for one of the AWS/RADIUSS events.

Also, I couldn't get links to registration pages for some prior year conferences (e.g., ISC) so I switched to just provide links to the slides.